### PR TITLE
Feature: 퇴근 등록 API 구현

### DIFF
--- a/src/main/java/io/devlabs/keytree/domains/attendance/application/AttendanceService.java
+++ b/src/main/java/io/devlabs/keytree/domains/attendance/application/AttendanceService.java
@@ -1,4 +1,4 @@
-package io.devlabs.keytree.domains.attendance.application.application;
+package io.devlabs.keytree.domains.attendance.application;
 
 import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceResponse;

--- a/src/main/java/io/devlabs/keytree/domains/attendance/application/application/AttendanceService.java
+++ b/src/main/java/io/devlabs/keytree/domains/attendance/application/application/AttendanceService.java
@@ -1,11 +1,11 @@
 package io.devlabs.keytree.domains.attendance.application.application;
 
+import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceRequest;
+import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceResponse;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceResponse;
 import io.devlabs.keytree.domains.attendance.domain.Attendance;
 import io.devlabs.keytree.domains.attendance.domain.AttendanceRepository;
-import io.devlabs.keytree.domains.schedule.application.dto.CreateScheduleResponse;
-import io.devlabs.keytree.domains.schedule.domain.Schedule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,14 +35,34 @@ public class AttendanceService {
                 .build();
     }
 
+    @Transactional
+    public CreateFinishAttendanceResponse createFinishAttendance(Long attendanceId, CreateFinishAttendanceRequest request) {
+        Attendance attendance =
+                attendanceRepository
+                        .findById(attendanceId)
+                        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 퇴근 요청입니다."));
+
+        attendance.finish(
+                request.getFinishedAt()
+        );
+
+        return CreateFinishAttendanceResponse.builder()
+                .id(attendance.getId())
+                .userId(attendance.getUserId())
+                .startedAt(attendance.getCreatedAt())
+                .finishedAt(attendance.getFinishedAt())
+                .build();
+    }
+
+
     @Transactional(readOnly = true)
-    public List<Attendance> getAttendances() {
+    public List<CreateFinishAttendanceResponse> getAttendances() {
         List<Attendance> attendances = attendanceRepository.findAll();
 
         return attendances.stream()
                 .map(
                         attendance ->
-                                Attendance.builder()
+                                CreateFinishAttendanceResponse.builder()
                                         .id(attendance.getId())
                                         .userId(attendance.getUserId())
                                         .startedAt(attendance.getStartedAt())

--- a/src/main/java/io/devlabs/keytree/domains/attendance/application/dto/CreateFinishAttendanceRequest.java
+++ b/src/main/java/io/devlabs/keytree/domains/attendance/application/dto/CreateFinishAttendanceRequest.java
@@ -1,0 +1,14 @@
+package io.devlabs.keytree.domains.attendance.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class CreateFinishAttendanceRequest {
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime finishedAt;
+}

--- a/src/main/java/io/devlabs/keytree/domains/attendance/application/dto/CreateFinishAttendanceResponse.java
+++ b/src/main/java/io/devlabs/keytree/domains/attendance/application/dto/CreateFinishAttendanceResponse.java
@@ -1,0 +1,22 @@
+package io.devlabs.keytree.domains.attendance.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CreateFinishAttendanceResponse {
+    private Long id;
+
+    private Long userId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime startedAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime finishedAt;
+}

--- a/src/main/java/io/devlabs/keytree/domains/attendance/domain/Attendance.java
+++ b/src/main/java/io/devlabs/keytree/domains/attendance/domain/Attendance.java
@@ -34,4 +34,8 @@ public class Attendance extends BaseTimeEntity {
     @NotNull
     @Comment("퇴근 일시")
     private LocalDateTime finishedAt;
+
+    public void finish(LocalDateTime finishedAt) {
+        this.finishedAt = finishedAt;
+    }
 }

--- a/src/main/java/io/devlabs/keytree/domains/attendance/presentation/AttendanceController.java
+++ b/src/main/java/io/devlabs/keytree/domains/attendance/presentation/AttendanceController.java
@@ -1,14 +1,13 @@
 package io.devlabs.keytree.domains.attendance.presentation;
 
 import io.devlabs.keytree.domains.attendance.application.application.AttendanceService;
+import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceRequest;
+import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceResponse;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceResponse;
 import io.devlabs.keytree.domains.attendance.domain.Attendance;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,8 +22,14 @@ public class AttendanceController {
         return attendanceService.createStartAttendance(request);
     }
 
+    @PatchMapping("/attendances/{attendanceId}")
+    public CreateFinishAttendanceResponse createFinishAttendance(@PathVariable Long attendanceId, @RequestBody CreateFinishAttendanceRequest request) {
+        return attendanceService.createFinishAttendance(attendanceId, request);
+    }
+
+
     @GetMapping("/attendances")
-    public List<Attendance> getAttendances() {
+    public List<CreateFinishAttendanceResponse> getAttendances() {
         return attendanceService.getAttendances();
     }
 }

--- a/src/main/java/io/devlabs/keytree/domains/attendance/presentation/AttendanceController.java
+++ b/src/main/java/io/devlabs/keytree/domains/attendance/presentation/AttendanceController.java
@@ -1,11 +1,10 @@
 package io.devlabs.keytree.domains.attendance.presentation;
 
-import io.devlabs.keytree.domains.attendance.application.application.AttendanceService;
+import io.devlabs.keytree.domains.attendance.application.AttendanceService;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceResponse;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceResponse;
-import io.devlabs.keytree.domains.attendance.domain.Attendance;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/test/java/io/devlabs/keytree/domains/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/io/devlabs/keytree/domains/attendance/application/AttendanceServiceTest.java
@@ -1,12 +1,12 @@
 package io.devlabs.keytree.domains.attendance.application;
 
 import io.devlabs.keytree.domains.attendance.application.application.AttendanceService;
+import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceRequest;
+import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceResponse;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceResponse;
 import io.devlabs.keytree.domains.attendance.domain.Attendance;
 import io.devlabs.keytree.domains.attendance.domain.AttendanceRepository;
-import io.devlabs.keytree.domains.schedule.application.dto.CreateScheduleResponse;
-import io.devlabs.keytree.domains.schedule.domain.Schedule;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -50,6 +51,22 @@ public class AttendanceServiceTest {
     }
 
     @Test
+    @DisplayName("퇴근 생성")
+    void createFinishAttendance() {
+        // given
+        Attendance attendance = createFinishAttendanceEntity(1L, createFinishAttendanceRequest());
+        when(attendanceRepository.findById(any(Long.class))).thenReturn(Optional.of(attendance));
+
+        // when
+        CreateFinishAttendanceRequest request = createFinishAttendanceRequest();
+        CreateFinishAttendanceResponse response = attendanceService.createFinishAttendance(attendance.getId(), request);
+
+        // then
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getFinishedAt()).isEqualTo(attendance.getFinishedAt());
+    }
+
+    @Test
     @DisplayName("출근 목록 조회")
     void getAttendance() {
         // given
@@ -60,8 +77,8 @@ public class AttendanceServiceTest {
         when(attendanceRepository.findAll()).thenReturn(attendances);
 
         // when
-        List<Attendance> foundAttendances = attendanceService.getAttendances();
-        List<Long> attendanceIds = foundAttendances.stream().map(Attendance::getId).toList();
+        List<CreateFinishAttendanceResponse> foundAttendances = attendanceService.getAttendances();
+        List<Long> attendanceIds = foundAttendances.stream().map(CreateFinishAttendanceResponse::getId).toList();
 
         // then
         assertThat(foundAttendances.size()).isEqualTo(attendances.size());
@@ -83,6 +100,24 @@ public class AttendanceServiceTest {
 
         CreateStartAttendanceRequest request = new CreateStartAttendanceRequest();
         request.setStartedAt(startedAt);
+
+        return request;
+    }
+
+    private Attendance createFinishAttendanceEntity(Long attendanceId, CreateFinishAttendanceRequest request) {
+        return Attendance.builder()
+                .id(attendanceId)
+                .finishedAt(request.getFinishedAt())
+                .build();
+    }
+
+    private CreateFinishAttendanceRequest createFinishAttendanceRequest() {
+        LocalDateTime finishedAt =
+                LocalDateTime.parse(
+                        "2023-08-27 00:00:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+        CreateFinishAttendanceRequest request = new CreateFinishAttendanceRequest();
+        request.setFinishedAt(finishedAt);
 
         return request;
     }

--- a/src/test/java/io/devlabs/keytree/domains/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/io/devlabs/keytree/domains/attendance/application/AttendanceServiceTest.java
@@ -1,6 +1,5 @@
 package io.devlabs.keytree.domains.attendance.application;
 
-import io.devlabs.keytree.domains.attendance.application.application.AttendanceService;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceResponse;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceRequest;

--- a/src/test/java/io/devlabs/keytree/domains/attendance/presentation/AttendanceControllerTest.java
+++ b/src/test/java/io/devlabs/keytree/domains/attendance/presentation/AttendanceControllerTest.java
@@ -1,6 +1,6 @@
 package io.devlabs.keytree.domains.attendance.presentation;
 
-import io.devlabs.keytree.domains.attendance.application.application.AttendanceService;
+import io.devlabs.keytree.domains.attendance.application.AttendanceService;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.domain.AttendanceType;

--- a/src/test/java/io/devlabs/keytree/domains/attendance/presentation/AttendanceControllerTest.java
+++ b/src/test/java/io/devlabs/keytree/domains/attendance/presentation/AttendanceControllerTest.java
@@ -1,6 +1,7 @@
 package io.devlabs.keytree.domains.attendance.presentation;
 
 import io.devlabs.keytree.domains.attendance.application.application.AttendanceService;
+import io.devlabs.keytree.domains.attendance.application.dto.CreateFinishAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.application.dto.CreateStartAttendanceRequest;
 import io.devlabs.keytree.domains.attendance.domain.AttendanceType;
 import io.restassured.RestAssured;
@@ -62,6 +63,44 @@ public class AttendanceControllerTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
+    @DisplayName("퇴근 등록 API")
+    @Test
+    void createFinishAttendance() {
+        // given
+        CreateStartAttendanceRequest createStartRequest = createStartAttendanceRequest();
+
+        ExtractableResponse<Response> createStartAttendanceResponse =
+                RestAssured.given()
+                        .body(createStartRequest)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when()
+                        .post("/attendances")
+                        .then()
+                        .extract();
+
+        // when
+        CreateFinishAttendanceRequest requestBody = createFinishAttendanceRequest();
+        Long attendanceId = createStartAttendanceResponse.jsonPath().getLong("id");
+
+
+        ExtractableResponse<Response> response =
+                RestAssured.given()
+                        .pathParam("attendanceId", attendanceId)
+                        .log()
+                        .all()
+                        .body(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when()
+                        .patch("/attendances/{attendanceId}")
+                        .then()
+                        .log()
+                        .all()
+                        .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
     @DisplayName("출근 목록 조회 API")
     @Test
     void getAttendance() {
@@ -97,6 +136,17 @@ public class AttendanceControllerTest {
         request.setUserId(userId);
         request.setAttendanceType(AttendanceType.START);
         request.setStartedAt(startedAt);
+
+        return request;
+    }
+
+    private CreateFinishAttendanceRequest createFinishAttendanceRequest() {
+        LocalDateTime finishedAt =
+                LocalDateTime.parse(
+                        "2023-08-29 00:00:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+        CreateFinishAttendanceRequest request = new CreateFinishAttendanceRequest();
+        request.setFinishedAt(finishedAt);
 
         return request;
     }


### PR DESCRIPTION
---
### PR Type ✔️

- [x] Feature - 기능 개발
- [ ] Fix - 버그 수정
- [ ] Code Style - 코드 스타일
- [ ] Refactoring - 리팩토링
- [ ] Document - 문서
- [ ] Others - 빌드, 배포 및 의존성 등 기타사항

---
### Summary(요약) ⭐
퇴근 등록 API 구현
---
### Describe your changes(상세) 🧾
**퇴근 생성 DTO**
 - 출근 생성 DTO는 초기 구현 단계여서 필수로 예상되는 필드로 구성했습니다.
 - 퇴근일시 필드 구성

**퇴근 생성 로직**
- 퇴근 시 출석고유아이디와 퇴근일시 값을가지고 고유아이디에 해당하는 attendance raw를 수정합니다.
- 출근과 퇴근을 raw로 관리를 할 수 있을 것 같아 해당 프로세스 로 구성했습니다.

**퇴근 생성 서비스 테스트 코드**
- 퇴근 로직 수행 후 attendanceId와 finishedAt 검증

**퇴근 생성 핸들러 테스트 코드**
- 출근 등록을 먼저 실시한 후 출근 등록한 곳에서 id값 추출하여 attendanceId에 할당합니다.
- 해당 attendanceId를 pathParam에 주입하여 테스트 코드를 구성했습니다.
---
### Issue Number or Link 🔗

---
### Reference

---

[//]: # (PR 타이틀은 "Type: 타이틀" 형식으로 작성)
[//]: # (Summary의 경우 작업의 전반적인 내용을 함축 및 요약하여 작성)
[//]: # (Describe your changes의 경우 무슨 상황에서 왜 이러한 변경이 필요했고, 어떻게 작업햇는지 상세 기술)
[//]: # (Issue의 경우 추후 필요시 사용)
[//]: # (Reference의 경우 해당 변경점에서 중요하게 찾아본 자료가 있거나, 이해하는데 도움이 되는 내용을 포함)